### PR TITLE
Adds preferredAspectRatio instances object support

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@apmg/mimas",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@apmg/mimas",
   "description": "A React component that takes an image endpoint from APM's APIs and returns a proper image with srcset.",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "main": "dist/index.js",
   "module": "dist/index.js",
   "license": "MIT",

--- a/src/Image/Image.test.js
+++ b/src/Image/Image.test.js
@@ -1,20 +1,24 @@
 import React from 'react';
 import { render, cleanup } from 'react-testing-library';
 import Image from './Image';
-import { image } from './testdata/image';
+import {
+  image,
+  imageWithPreferred,
+  imageWithoutPreferredSlug
+} from './testdata/image';
 import 'jest-prop-type-error';
 
 afterEach(cleanup);
 
 // SUCCESSES
 
-test('Creates an img with the correct alt, src, and srcSet when aspectRatio prop is provided', () => {
+test('Creates an img with the correct alt, src, and srcSet when aspectRatio prop is provided, prioritizes aspectRatio prop over preferred', () => {
   const props = {
     aspectRatio: 'widescreen'
   };
 
   const { container } = render(
-    <Image image={image} aspectRatio={props.aspectRatio} />
+    <Image image={imageWithPreferred} aspectRatio={props.aspectRatio} />
   );
 
   expect(container.firstChild.getAttribute('alt')).toBe(
@@ -52,6 +56,20 @@ test('Takes in an optional sizes string, specifying specific image behavior with
   );
 });
 
+test('Creates an img with the preferred aspect ratio when image.preferredAspectRatio is included and no aspectRatio prop is provided', () => {
+  const { container } = render(<Image image={imageWithPreferred} />);
+
+  expect(container.firstChild.getAttribute('alt')).toBe(
+    'Serena Brook opens our show at The Town Hall'
+  );
+  expect(container.firstChild.getAttribute('src')).toBe(
+    'https://img.apmcdn.org/c2c452354fbff94d720ba8f86e2c71ba7427b306/uncropped/f5db37-20181220-serena-brook-opens-our-show-at-the-town-hall.jpg'
+  );
+  expect(container.firstChild.getAttribute('srcset')).toBe(
+    'https://img.apmcdn.org/c2c452354fbff94d720ba8f86e2c71ba7427b306/square/5ecd52-20181220-serena-brook-opens-our-show-at-the-town-hall.jpg 400w,https://img.apmcdn.org/c2c452354fbff94d720ba8f86e2c71ba7427b306/square/de193e-20181220-serena-brook-opens-our-show-at-the-town-hall.jpg 600w,https://img.apmcdn.org/c2c452354fbff94d720ba8f86e2c71ba7427b306/square/7cb7e2-20181220-serena-brook-opens-our-show-at-the-town-hall.jpg 1000w,https://img.apmcdn.org/c2c452354fbff94d720ba8f86e2c71ba7427b306/square/822d4e-20181220-serena-brook-opens-our-show-at-the-town-hall.jpg 1400w,https://img.apmcdn.org/c2c452354fbff94d720ba8f86e2c71ba7427b306/square/f977a8-20181220-serena-brook-opens-our-show-at-the-town-hall.jpg 2000w'
+  );
+});
+
 test('Creates an img with the correct alt, src, and srcSet and className when the elementClass property is provided', () => {
   const props = {
     aspectRatio: 'widescreen',
@@ -78,8 +96,8 @@ test('Creates an img with the correct alt, src, and srcSet and className when th
   );
 });
 
-test('Creates an img with the correct alt, src, and defaut srcSet when no aspectRatio prop is provided', () => {
-  const { container } = render(<Image image={image} />);
+test('Creates an img with the correct alt, src, and "uncropped" srcSet when no aspectRatio prop or image.preferred_aspect_ratio_slug is provided', () => {
+  const { container } = render(<Image image={imageWithoutPreferredSlug} />);
 
   expect(container.firstChild.getAttribute('alt')).toBe(
     'Serena Brook opens our show at The Town Hall'
@@ -87,7 +105,9 @@ test('Creates an img with the correct alt, src, and defaut srcSet when no aspect
   expect(container.firstChild.getAttribute('src')).toBe(
     'https://img.apmcdn.org/c2c452354fbff94d720ba8f86e2c71ba7427b306/uncropped/f5db37-20181220-serena-brook-opens-our-show-at-the-town-hall.jpg'
   );
-  expect(container.firstChild.getAttribute('srcset')).toBe(image.srcset);
+  expect(container.firstChild.getAttribute('srcset')).toBe(
+    'https://img.apmcdn.org/c2c452354fbff94d720ba8f86e2c71ba7427b306/uncropped/35bd3b-20181220-serena-brook-opens-our-show-at-the-town-hall.jpg 400w,https://img.apmcdn.org/c2c452354fbff94d720ba8f86e2c71ba7427b306/uncropped/f5db37-20181220-serena-brook-opens-our-show-at-the-town-hall.jpg 600w,https://img.apmcdn.org/c2c452354fbff94d720ba8f86e2c71ba7427b306/uncropped/04a63f-20181220-serena-brook-opens-our-show-at-the-town-hall.jpg 1000w,https://img.apmcdn.org/c2c452354fbff94d720ba8f86e2c71ba7427b306/uncropped/72bc48-20181220-serena-brook-opens-our-show-at-the-town-hall.jpg 1400w,https://img.apmcdn.org/c2c452354fbff94d720ba8f86e2c71ba7427b306/uncropped/f20034-20181220-serena-brook-opens-our-show-at-the-town-hall.jpg 2000w'
+  );
 });
 
 test('Creates an img when an image object is not provided, but a fallbackSrc, fallbackSrcSet and alt are provided', () => {
@@ -142,7 +162,9 @@ test('Creates the correct img when an image prop and all of the fallbacks are pr
   expect(container.firstChild.getAttribute('src')).toBe(
     'https://img.apmcdn.org/c2c452354fbff94d720ba8f86e2c71ba7427b306/uncropped/f5db37-20181220-serena-brook-opens-our-show-at-the-town-hall.jpg'
   );
-  expect(container.firstChild.getAttribute('srcset')).toBe(image.srcset);
+  expect(container.firstChild.getAttribute('srcset')).toBe(
+    'https://img.apmcdn.org/c2c452354fbff94d720ba8f86e2c71ba7427b306/widescreen/e428bc-20181220-serena-brook-opens-our-show-at-the-town-hall.jpg 400w,https://img.apmcdn.org/c2c452354fbff94d720ba8f86e2c71ba7427b306/widescreen/58b2ba-20181220-serena-brook-opens-our-show-at-the-town-hall.jpg 600w,https://img.apmcdn.org/c2c452354fbff94d720ba8f86e2c71ba7427b306/widescreen/95c885-20181220-serena-brook-opens-our-show-at-the-town-hall.jpg 1000w,https://img.apmcdn.org/c2c452354fbff94d720ba8f86e2c71ba7427b306/widescreen/b3a373-20181220-serena-brook-opens-our-show-at-the-town-hall.jpg 1400w,https://img.apmcdn.org/c2c452354fbff94d720ba8f86e2c71ba7427b306/widescreen/6ceb83-20181220-serena-brook-opens-our-show-at-the-town-hall.jpg 2000w'
+  );
 });
 
 test('Creates the a basic img with an empty srcset if only a alt and fallbackSrc are provided', () => {
@@ -162,7 +184,7 @@ test('Creates the a basic img with an empty srcset if only a alt and fallbackSrc
   expect(container.firstChild.getAttribute('src')).toBe(
     'https://s3-us-west-2.amazonaws.com/s.cdpn.io/298/wolf_20131015_003_1400.jpg'
   );
-  expect(container.firstChild.getAttribute('srcset')).toBe('');
+  expect(container.firstChild.getAttribute('srcset')).toBe(null);
 });
 
 // FAILURES

--- a/src/Image/testdata/image.js
+++ b/src/Image/testdata/image.js
@@ -207,3 +207,335 @@ export const image = {
   srcset:
     'https://img.apmcdn.org/c2c452354fbff94d720ba8f86e2c71ba7427b306/widescreen/e428bc-20181220-serena-brook-opens-our-show-at-the-town-hall.jpg 400w, https://img.apmcdn.org/c2c452354fbff94d720ba8f86e2c71ba7427b306/widescreen/58b2ba-20181220-serena-brook-opens-our-show-at-the-town-hall.jpg 600w, https://img.apmcdn.org/c2c452354fbff94d720ba8f86e2c71ba7427b306/widescreen/95c885-20181220-serena-brook-opens-our-show-at-the-town-hall.jpg 1000w, https://img.apmcdn.org/c2c452354fbff94d720ba8f86e2c71ba7427b306/widescreen/b3a373-20181220-serena-brook-opens-our-show-at-the-town-hall.jpg 1400w, https://img.apmcdn.org/c2c452354fbff94d720ba8f86e2c71ba7427b306/widescreen/6ceb83-20181220-serena-brook-opens-our-show-at-the-town-hall.jpg 2000w'
 };
+
+export const imageWithoutPreferredSlug = {
+  aspect_ratios: {
+    widescreen: {
+      instances: [
+        {
+          width: 400,
+          url:
+            'https://img.apmcdn.org/c2c452354fbff94d720ba8f86e2c71ba7427b306/widescreen/e428bc-20181220-serena-brook-opens-our-show-at-the-town-hall.jpg',
+          height: 225
+        },
+        {
+          width: 600,
+          url:
+            'https://img.apmcdn.org/c2c452354fbff94d720ba8f86e2c71ba7427b306/widescreen/58b2ba-20181220-serena-brook-opens-our-show-at-the-town-hall.jpg',
+          height: 337
+        },
+        {
+          width: 1000,
+          url:
+            'https://img.apmcdn.org/c2c452354fbff94d720ba8f86e2c71ba7427b306/widescreen/95c885-20181220-serena-brook-opens-our-show-at-the-town-hall.jpg',
+          height: 562
+        },
+        {
+          width: 1400,
+          url:
+            'https://img.apmcdn.org/c2c452354fbff94d720ba8f86e2c71ba7427b306/widescreen/b3a373-20181220-serena-brook-opens-our-show-at-the-town-hall.jpg',
+          height: 787
+        },
+        {
+          width: 2000,
+          url:
+            'https://img.apmcdn.org/c2c452354fbff94d720ba8f86e2c71ba7427b306/widescreen/6ceb83-20181220-serena-brook-opens-our-show-at-the-town-hall.jpg',
+          height: 1124
+        }
+      ],
+      slug: 'widescreen'
+    },
+    uncropped: {
+      instances: [
+        {
+          width: 400,
+          url:
+            'https://img.apmcdn.org/c2c452354fbff94d720ba8f86e2c71ba7427b306/uncropped/35bd3b-20181220-serena-brook-opens-our-show-at-the-town-hall.jpg',
+          height: 320
+        },
+        {
+          width: 600,
+          url:
+            'https://img.apmcdn.org/c2c452354fbff94d720ba8f86e2c71ba7427b306/uncropped/f5db37-20181220-serena-brook-opens-our-show-at-the-town-hall.jpg',
+          height: 480
+        },
+        {
+          width: 1000,
+          url:
+            'https://img.apmcdn.org/c2c452354fbff94d720ba8f86e2c71ba7427b306/uncropped/04a63f-20181220-serena-brook-opens-our-show-at-the-town-hall.jpg',
+          height: 800
+        },
+        {
+          width: 1400,
+          url:
+            'https://img.apmcdn.org/c2c452354fbff94d720ba8f86e2c71ba7427b306/uncropped/72bc48-20181220-serena-brook-opens-our-show-at-the-town-hall.jpg',
+          height: 1120
+        },
+        {
+          width: 2000,
+          url:
+            'https://img.apmcdn.org/c2c452354fbff94d720ba8f86e2c71ba7427b306/uncropped/f20034-20181220-serena-brook-opens-our-show-at-the-town-hall.jpg',
+          height: 1600
+        }
+      ],
+      slug: 'uncropped'
+    }
+  },
+  long_caption: 'Serena Brook opens our show at The Town Hall',
+  short_caption: 'Serena Brook opens our show at The Town Hall',
+  width: 'full',
+  id: 'c2c452354fbff94d720ba8f86e2c71ba7427b306',
+  credit_url: '',
+  type: 'apmImage',
+  float: 'none',
+  credit: 'American Public Media',
+  fallback:
+    'https://img.apmcdn.org/c2c452354fbff94d720ba8f86e2c71ba7427b306/uncropped/f5db37-20181220-serena-brook-opens-our-show-at-the-town-hall.jpg',
+  srcset:
+    'https://img.apmcdn.org/c2c452354fbff94d720ba8f86e2c71ba7427b306/widescreen/e428bc-20181220-serena-brook-opens-our-show-at-the-town-hall.jpg 400w, https://img.apmcdn.org/c2c452354fbff94d720ba8f86e2c71ba7427b306/widescreen/58b2ba-20181220-serena-brook-opens-our-show-at-the-town-hall.jpg 600w, https://img.apmcdn.org/c2c452354fbff94d720ba8f86e2c71ba7427b306/widescreen/95c885-20181220-serena-brook-opens-our-show-at-the-town-hall.jpg 1000w, https://img.apmcdn.org/c2c452354fbff94d720ba8f86e2c71ba7427b306/widescreen/b3a373-20181220-serena-brook-opens-our-show-at-the-town-hall.jpg 1400w, https://img.apmcdn.org/c2c452354fbff94d720ba8f86e2c71ba7427b306/widescreen/6ceb83-20181220-serena-brook-opens-our-show-at-the-town-hall.jpg 2000w'
+};
+
+export const imageWithPreferred = {
+  preferredAspectRatio: {
+    instances: [
+      {
+        width: 400,
+        url:
+          'https://img.apmcdn.org/c2c452354fbff94d720ba8f86e2c71ba7427b306/square/5ecd52-20181220-serena-brook-opens-our-show-at-the-town-hall.jpg',
+        height: 400
+      },
+      {
+        width: 600,
+        url:
+          'https://img.apmcdn.org/c2c452354fbff94d720ba8f86e2c71ba7427b306/square/de193e-20181220-serena-brook-opens-our-show-at-the-town-hall.jpg',
+        height: 600
+      },
+      {
+        width: 1000,
+        url:
+          'https://img.apmcdn.org/c2c452354fbff94d720ba8f86e2c71ba7427b306/square/7cb7e2-20181220-serena-brook-opens-our-show-at-the-town-hall.jpg',
+        height: 1000
+      },
+      {
+        width: 1400,
+        url:
+          'https://img.apmcdn.org/c2c452354fbff94d720ba8f86e2c71ba7427b306/square/822d4e-20181220-serena-brook-opens-our-show-at-the-town-hall.jpg',
+        height: 1400
+      },
+      {
+        width: 2000,
+        url:
+          'https://img.apmcdn.org/c2c452354fbff94d720ba8f86e2c71ba7427b306/square/f977a8-20181220-serena-brook-opens-our-show-at-the-town-hall.jpg',
+        height: 2000
+      }
+    ],
+    slug: 'square'
+  },
+  aspect_ratios: {
+    normal: {
+      instances: [
+        {
+          width: 400,
+          url:
+            'https://img.apmcdn.org/c2c452354fbff94d720ba8f86e2c71ba7427b306/normal/fa6aa0-20181220-serena-brook-opens-our-show-at-the-town-hall.jpg',
+          height: 301
+        },
+        {
+          width: 600,
+          url:
+            'https://img.apmcdn.org/c2c452354fbff94d720ba8f86e2c71ba7427b306/normal/00b407-20181220-serena-brook-opens-our-show-at-the-town-hall.jpg',
+          height: 451
+        },
+        {
+          width: 1000,
+          url:
+            'https://img.apmcdn.org/c2c452354fbff94d720ba8f86e2c71ba7427b306/normal/10ac72-20181220-serena-brook-opens-our-show-at-the-town-hall.jpg',
+          height: 752
+        },
+        {
+          width: 1400,
+          url:
+            'https://img.apmcdn.org/c2c452354fbff94d720ba8f86e2c71ba7427b306/normal/6e721c-20181220-serena-brook-opens-our-show-at-the-town-hall.jpg',
+          height: 1053
+        },
+        {
+          width: 2000,
+          url:
+            'https://img.apmcdn.org/c2c452354fbff94d720ba8f86e2c71ba7427b306/normal/f49c92-20181220-serena-brook-opens-our-show-at-the-town-hall.jpg',
+          height: 1504
+        }
+      ],
+      slug: 'normal'
+    },
+    square: {
+      instances: [
+        {
+          width: 400,
+          url:
+            'https://img.apmcdn.org/c2c452354fbff94d720ba8f86e2c71ba7427b306/square/5ecd52-20181220-serena-brook-opens-our-show-at-the-town-hall.jpg',
+          height: 400
+        },
+        {
+          width: 600,
+          url:
+            'https://img.apmcdn.org/c2c452354fbff94d720ba8f86e2c71ba7427b306/square/de193e-20181220-serena-brook-opens-our-show-at-the-town-hall.jpg',
+          height: 600
+        },
+        {
+          width: 1000,
+          url:
+            'https://img.apmcdn.org/c2c452354fbff94d720ba8f86e2c71ba7427b306/square/7cb7e2-20181220-serena-brook-opens-our-show-at-the-town-hall.jpg',
+          height: 1000
+        },
+        {
+          width: 1400,
+          url:
+            'https://img.apmcdn.org/c2c452354fbff94d720ba8f86e2c71ba7427b306/square/822d4e-20181220-serena-brook-opens-our-show-at-the-town-hall.jpg',
+          height: 1400
+        },
+        {
+          width: 2000,
+          url:
+            'https://img.apmcdn.org/c2c452354fbff94d720ba8f86e2c71ba7427b306/square/f977a8-20181220-serena-brook-opens-our-show-at-the-town-hall.jpg',
+          height: 2000
+        }
+      ],
+      slug: 'square'
+    },
+    thumbnail: {
+      instances: [
+        {
+          width: 120,
+          url:
+            'https://img.apmcdn.org/c2c452354fbff94d720ba8f86e2c71ba7427b306/thumbnail/e8796f-20181220-serena-brook-opens-our-show-at-the-town-hall.jpg',
+          height: 90
+        },
+        {
+          width: 300,
+          url:
+            'https://img.apmcdn.org/c2c452354fbff94d720ba8f86e2c71ba7427b306/thumbnail/dfad0f-20181220-serena-brook-opens-our-show-at-the-town-hall.jpg',
+          height: 226
+        }
+      ],
+      slug: 'thumbnail'
+    },
+    widescreen: {
+      instances: [
+        {
+          width: 400,
+          url:
+            'https://img.apmcdn.org/c2c452354fbff94d720ba8f86e2c71ba7427b306/widescreen/e428bc-20181220-serena-brook-opens-our-show-at-the-town-hall.jpg',
+          height: 225
+        },
+        {
+          width: 600,
+          url:
+            'https://img.apmcdn.org/c2c452354fbff94d720ba8f86e2c71ba7427b306/widescreen/58b2ba-20181220-serena-brook-opens-our-show-at-the-town-hall.jpg',
+          height: 337
+        },
+        {
+          width: 1000,
+          url:
+            'https://img.apmcdn.org/c2c452354fbff94d720ba8f86e2c71ba7427b306/widescreen/95c885-20181220-serena-brook-opens-our-show-at-the-town-hall.jpg',
+          height: 562
+        },
+        {
+          width: 1400,
+          url:
+            'https://img.apmcdn.org/c2c452354fbff94d720ba8f86e2c71ba7427b306/widescreen/b3a373-20181220-serena-brook-opens-our-show-at-the-town-hall.jpg',
+          height: 787
+        },
+        {
+          width: 2000,
+          url:
+            'https://img.apmcdn.org/c2c452354fbff94d720ba8f86e2c71ba7427b306/widescreen/6ceb83-20181220-serena-brook-opens-our-show-at-the-town-hall.jpg',
+          height: 1124
+        }
+      ],
+      slug: 'widescreen'
+    },
+    portrait: {
+      instances: [
+        {
+          width: 400,
+          url:
+            'https://img.apmcdn.org/c2c452354fbff94d720ba8f86e2c71ba7427b306/portrait/e6415b-20181220-serena-brook-opens-our-show-at-the-town-hall.jpg',
+          height: 500
+        },
+        {
+          width: 600,
+          url:
+            'https://img.apmcdn.org/c2c452354fbff94d720ba8f86e2c71ba7427b306/portrait/0ebc89-20181220-serena-brook-opens-our-show-at-the-town-hall.jpg',
+          height: 750
+        },
+        {
+          width: 1000,
+          url:
+            'https://img.apmcdn.org/c2c452354fbff94d720ba8f86e2c71ba7427b306/portrait/fed99c-20181220-serena-brook-opens-our-show-at-the-town-hall.jpg',
+          height: 1250
+        },
+        {
+          width: 1400,
+          url:
+            'https://img.apmcdn.org/c2c452354fbff94d720ba8f86e2c71ba7427b306/portrait/523b4b-20181220-serena-brook-opens-our-show-at-the-town-hall.jpg',
+          height: 1750
+        },
+        {
+          width: 1883,
+          url:
+            'https://img.apmcdn.org/c2c452354fbff94d720ba8f86e2c71ba7427b306/portrait/766692-20181220-serena-brook-opens-our-show-at-the-town-hall.jpg',
+          height: 2354
+        }
+      ],
+      slug: 'portrait'
+    },
+    uncropped: {
+      instances: [
+        {
+          width: 400,
+          url:
+            'https://img.apmcdn.org/c2c452354fbff94d720ba8f86e2c71ba7427b306/uncropped/35bd3b-20181220-serena-brook-opens-our-show-at-the-town-hall.jpg',
+          height: 320
+        },
+        {
+          width: 600,
+          url:
+            'https://img.apmcdn.org/c2c452354fbff94d720ba8f86e2c71ba7427b306/uncropped/f5db37-20181220-serena-brook-opens-our-show-at-the-town-hall.jpg',
+          height: 480
+        },
+        {
+          width: 1000,
+          url:
+            'https://img.apmcdn.org/c2c452354fbff94d720ba8f86e2c71ba7427b306/uncropped/04a63f-20181220-serena-brook-opens-our-show-at-the-town-hall.jpg',
+          height: 800
+        },
+        {
+          width: 1400,
+          url:
+            'https://img.apmcdn.org/c2c452354fbff94d720ba8f86e2c71ba7427b306/uncropped/72bc48-20181220-serena-brook-opens-our-show-at-the-town-hall.jpg',
+          height: 1120
+        },
+        {
+          width: 2000,
+          url:
+            'https://img.apmcdn.org/c2c452354fbff94d720ba8f86e2c71ba7427b306/uncropped/f20034-20181220-serena-brook-opens-our-show-at-the-town-hall.jpg',
+          height: 1600
+        }
+      ],
+      slug: 'uncropped'
+    }
+  },
+  long_caption: 'Serena Brook opens our show at The Town Hall',
+  short_caption: 'Serena Brook opens our show at The Town Hall',
+  width: 'full',
+  preferred_aspect_ratio_slug: 'widescreen',
+  id: 'c2c452354fbff94d720ba8f86e2c71ba7427b306',
+  credit_url: '',
+  type: 'apmImage',
+  float: 'none',
+  credit: 'American Public Media',
+  fallback:
+    'https://img.apmcdn.org/c2c452354fbff94d720ba8f86e2c71ba7427b306/uncropped/f5db37-20181220-serena-brook-opens-our-show-at-the-town-hall.jpg',
+  srcset:
+    'https://img.apmcdn.org/c2c452354fbff94d720ba8f86e2c71ba7427b306/widescreen/e428bc-20181220-serena-brook-opens-our-show-at-the-town-hall.jpg 400w, https://img.apmcdn.org/c2c452354fbff94d720ba8f86e2c71ba7427b306/widescreen/58b2ba-20181220-serena-brook-opens-our-show-at-the-town-hall.jpg 600w, https://img.apmcdn.org/c2c452354fbff94d720ba8f86e2c71ba7427b306/widescreen/95c885-20181220-serena-brook-opens-our-show-at-the-town-hall.jpg 1000w, https://img.apmcdn.org/c2c452354fbff94d720ba8f86e2c71ba7427b306/widescreen/b3a373-20181220-serena-brook-opens-our-show-at-the-town-hall.jpg 1400w, https://img.apmcdn.org/c2c452354fbff94d720ba8f86e2c71ba7427b306/widescreen/6ceb83-20181220-serena-brook-opens-our-show-at-the-town-hall.jpg 2000w'
+};


### PR DESCRIPTION
In order to properly support including a `preferredAspectRatio` object in the `image` prop, I did a bit of a refactor of this component. Primarily this was to separate the concerns a little bit more, using a more functional style with return values and getting rid of the `imageProps` var, as well as separating things out into a few more functions.

Some of the tests had to be revised a little bit because they weren't quite testing for the correct behavior, and I added another test for the aforementioned `preferredAspectRatio` object. As a note, in the data, `preferredAspectRatio` exists as a sibling to `aspect_ratios`, not as a child. This is what necessitated the re-work