### PR TITLE
Added the aspect-ratio fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@apmg/mimas",
   "description": "A React component that takes an image endpoint from APM's APIs and returns a proper image with srcset.",
-  "version": "2.0.3",
+  "version": "2.0.4",
   "main": "dist/index.js",
   "module": "dist/index.js",
   "license": "MIT",

--- a/src/Image/Image.js
+++ b/src/Image/Image.js
@@ -51,6 +51,20 @@ const Image = (props) => {
   if (fallbackImage.height) fallbackImageProps.height = fallbackImage.height
   if (props.fetchPriority)
     fallbackImageProps.fetchPriority = props.fetchPriority
+
+  const aspectRatioCssMap = {
+    widescreen: '16 / 9',
+    normal: '4 / 3',
+    square: '1 / 1',
+    portrait: '8 / 10',
+    thumbnail: '4 / 3'
+  }
+  if (props.aspectRatio && aspectRatioCssMap[props.aspectRatio]) {
+    fallbackImageProps.style = {
+      aspectRatio: aspectRatioCssMap[props.aspectRatio]
+    }
+  }
+
   // We need a <source> element for each props.media for webp  and the same for non webp
   // So if there are 2 items in props.media and we have webp image there will be 3 <source> elements
 

--- a/src/Image/Image.js
+++ b/src/Image/Image.js
@@ -63,6 +63,14 @@ const Image = (props) => {
     fallbackImageProps.style = {
       aspectRatio: aspectRatioCssMap[props.aspectRatio]
     }
+  } else if (
+    props.aspectRatio === 'uncropped' &&
+    fallbackImage.width &&
+    fallbackImage.height
+  ) {
+    fallbackImageProps.style = {
+      aspectRatio: `${fallbackImage.width} / ${fallbackImage.height}`
+    }
   }
 
   // We need a <source> element for each props.media for webp  and the same for non webp

--- a/src/Image/__tests__/Image.test.js
+++ b/src/Image/__tests__/Image.test.js
@@ -225,6 +225,37 @@ test('creates image based on data when all fallbacks are also provided', () => {
   )
 })
 
+test('applies correct aspect-ratio style to fallback img for each known aspect ratio', () => {
+  const cases = [
+    ['widescreen', '16 / 9'],
+    ['normal', '4 / 3'],
+    ['square', '1 / 1'],
+    ['portrait', '8 / 10'],
+    ['thumbnail', '4 / 3']
+  ]
+
+  cases.forEach(([aspectRatio, expectedRatio]) => {
+    const { getByAltText, unmount } = render(
+      <Image image={image} aspectRatio={aspectRatio} />
+    )
+    expect(getByAltText('Stanley Turrentine Short').style.aspectRatio).toBe(
+      expectedRatio
+    )
+    unmount()
+  })
+})
+
+test('does not apply aspect-ratio style when aspectRatio is uncropped or omitted', () => {
+  const { getByAltText: getByAltText1, unmount: unmount1 } = render(
+    <Image image={image} aspectRatio="uncropped" />
+  )
+  expect(getByAltText1('Stanley Turrentine Short')).not.toHaveAttribute('style')
+  unmount1()
+
+  const { getByAltText: getByAltText2 } = render(<Image image={image} />)
+  expect(getByAltText2('Stanley Turrentine Short')).not.toHaveAttribute('style')
+})
+
 // FAILURES
 
 test('throws when provided poorly shaped image data', () => {

--- a/src/Image/__tests__/Image.test.js
+++ b/src/Image/__tests__/Image.test.js
@@ -245,15 +245,30 @@ test('applies correct aspect-ratio style to fallback img for each known aspect r
   })
 })
 
-test('does not apply aspect-ratio style when aspectRatio is uncropped or omitted', () => {
-  const { getByAltText: getByAltText1, unmount: unmount1 } = render(
-    <Image image={image} aspectRatio="uncropped" />
-  )
-  expect(getByAltText1('Stanley Turrentine Short')).not.toHaveAttribute('style')
-  unmount1()
+test('applies runtime aspect-ratio style to fallback img when aspectRatio is uncropped', () => {
+  const uncroppedImage = {
+    preferredAspectRatio: {
+      instances: [
+        {
+          url: 'https://img.apmcdn.org/test/uncropped/photo-400.jpg',
+          width: 400,
+          height: 300
+        }
+      ]
+    },
+    fallback: 'https://img.apmcdn.org/test/uncropped/photo-400.jpg',
+    short_caption: 'Test Uncropped'
+  }
 
-  const { getByAltText: getByAltText2 } = render(<Image image={image} />)
-  expect(getByAltText2('Stanley Turrentine Short')).not.toHaveAttribute('style')
+  const { getByAltText } = render(
+    <Image image={uncroppedImage} aspectRatio="uncropped" />
+  )
+  expect(getByAltText('Test Uncropped').style.aspectRatio).toBe('400 / 300')
+})
+
+test('does not apply aspect-ratio style when aspectRatio is omitted', () => {
+  const { getByAltText } = render(<Image image={image} />)
+  expect(getByAltText('Stanley Turrentine Short')).not.toHaveAttribute('style')
 })
 
 // FAILURES


### PR DESCRIPTION
The <Image> component renders a <picture> element with <source> tags serving correctly-cropped images for each   
  aspect ratio. However, the fallback <img> at the bottom of the <picture> was getting its width and height from 
  whatever the CMS happened to store for that URL — not from the aspectRatio prop being requested.                 
                                                                             
  Before the browser loads the actual image, it uses those width/height attributes to pre-allocate space on the    
  page. If you asked for aspectRatio="widescreen" (16:9) but the fallback <img> had width="600" height="400" (3:2) 
  from the CMS, the browser would reserve the wrong amount of vertical space. Then when the image actually loaded
  at the correct crop, the layout would shift to compensate — causing a measurable CLS (Cumulative Layout Shift)
  score hit.

  The fix adds a CSS aspect-ratio inline style to the fallback <img> that matches the requested aspectRatio prop.
  CSS aspect-ratio takes precedence over mismatched width/height HTML attributes for layout pre-allocation
  purposes, so the browser reserves the right space from the start. The width/height attributes are kept because
  they still help with resource prioritization — only the layout pre-allocation is being corrected.
